### PR TITLE
Update links to examples on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ bot.startPolling()
 
 ## More interesting one
 
-Look at the code here :  [example.ts](example.ts) / [example.js](example.js)
+Look at the code here :  [example.ts](examples/main-typescript.ts) / [example.js](examples/main-javascript.js)
 
 ![Example Food Menu](media/example-food.gif)
 


### PR DESCRIPTION
I noticed the example links pointed to example.ts and example.js, wich apperently do not work anymore.

I've updated them to be examples/main-typescript.ts and examples/main-javascript.js, respectively